### PR TITLE
Allow uploading custom logos for accounts

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -3,7 +3,7 @@ class AccountsController < ApplicationController
   include Periodable
 
   def index
-    @manual_accounts = family.accounts.manual.alphabetically
+    @manual_accounts = family.accounts.manual.with_attached_logo.alphabetically
     @plaid_items = family.plaid_items.ordered
 
     render layout: "settings"

--- a/app/controllers/concerns/accountable_resource.rb
+++ b/app/controllers/concerns/accountable_resource.rb
@@ -80,7 +80,7 @@ module AccountableResource
 
     def account_params
       params.require(:account).permit(
-        :name, :balance, :subtype, :currency, :accountable_type, :return_to,
+        :name, :balance, :subtype, :currency, :accountable_type, :return_to, :logo,
         accountable_attributes: self.class.permitted_accountable_attributes
       )
     end

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -11,6 +11,13 @@
 
     <%= form.text_field :name, placeholder: t(".name_placeholder"), required: "required", label: t(".name_label") %>
 
+    <div class="form-field">
+      <div class="form-field__body">
+        <%= form.label :logo, t(".logo"), class: "form-field__label" %>
+        <%= form.file_field :logo, class: "form-field__input" %>
+      </div>
+    </div>
+
     <% unless account.linked? %>
       <%= form.money_field :balance, label: t(".balance"), required: true, default_currency: Current.family.currency %>
     <% end %>

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -17,6 +17,7 @@ en:
       balance: Current balance
       name_label: Account name
       name_placeholder: Example account name
+      logo: Logo
     index:
       accounts: Accounts
       manual_accounts:

--- a/config/locales/views/accounts/nb.yml
+++ b/config/locales/views/accounts/nb.yml
@@ -17,6 +17,7 @@ nb:
       balance: Nåværende balanse
       name_label: Kontonavn
       name_placeholder: Eksempel på kontonavn
+      logo: Logo
     index:
       accounts: Kontoer
       manual_accounts:

--- a/config/locales/views/accounts/tr.yml
+++ b/config/locales/views/accounts/tr.yml
@@ -17,6 +17,7 @@ tr:
       balance: Güncel bakiye
       name_label: Hesap adı
       name_placeholder: Örnek hesap adı
+      logo: Logo
     index:
       accounts: Hesaplar
       manual_accounts:

--- a/test/system/account_logos_test.rb
+++ b/test/system/account_logos_test.rb
@@ -1,0 +1,18 @@
+require "application_system_test_case"
+
+class AccountLogosTest < ApplicationSystemTestCase
+  setup do
+    sign_in users(:family_admin)
+  end
+
+  test "user can upload logo for account" do
+    account = accounts(:depository)
+
+    visit edit_account_path(account)
+    attach_file "account_logo", file_fixture("square-placeholder.png")
+    click_button "Update Account"
+
+    assert_selector "img[src*='square-placeholder.png']"
+    assert account.reload.logo.attached?
+  end
+end


### PR DESCRIPTION
## Summary
- allow attaching a logo to accounts
- load logos when listing manual accounts
- test uploading account logos

## Testing
- `bundle exec rubocop app/controllers/concerns/accountable_resource.rb app/controllers/accounts_controller.rb test/system/account_logos_test.rb`
- `bundle exec erblint app/views/accounts/_form.html.erb`
- `bin/rails test` *(fails: ActiveRecord::DatabaseConnectionError: There is an issue connecting with your hostname: 127.0.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_688e3430d4a4832487b7a414836c2ce2