### PR TITLE
Add script-based transaction syncing with pushTAN handling

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -88,6 +88,14 @@ class Account < ApplicationRecord
     end
   end
 
+  # Path to custom Python script used for transaction syncing
+  validates :sync_script_path, length: { maximum: 255 }, allow_nil: true
+
+  # Broadcast a pushTAN requirement to the UI
+  def broadcast_push_tan_required
+    Account::PushTanRequiredEvent.new(self).broadcast
+  end
+
   def destroy_later
     mark_for_deletion!
     DestroyJob.perform_later(self)

--- a/app/models/account/push_tan_required_event.rb
+++ b/app/models/account/push_tan_required_event.rb
@@ -1,0 +1,16 @@
+class Account::PushTanRequiredEvent
+  attr_reader :account
+
+  def initialize(account)
+    @account = account
+  end
+
+  def broadcast
+    account.broadcast_replace_to(
+      account.family,
+      target: "modal",
+      partial: "accounts/push_tan_required",
+      locals: { account: account }
+    )
+  end
+end

--- a/app/models/account/syncer.rb
+++ b/app/models/account/syncer.rb
@@ -6,6 +6,7 @@ class Account::Syncer
   end
 
   def perform_sync(sync)
+    fetch_transactions_from_script
     Rails.logger.info("Processing balances (#{account.linked? ? 'reverse' : 'forward'})")
     import_market_data
     materialize_balances
@@ -33,5 +34,15 @@ class Account::Syncer
     rescue => e
       Rails.logger.error("Error syncing market data for account #{account.id}: #{e.message}")
       Sentry.capture_exception(e)
+    end
+
+    def fetch_transactions_from_script
+      return unless account.sync_script_path.present?
+
+      added = Account::TransactionScriptRunner.new(account).run
+      Rails.logger.info("Imported #{added} transactions via script for account #{account.id}")
+    rescue Account::TransactionScriptRunner::PushTanRequired
+      account.broadcast_push_tan_required
+      raise
     end
 end

--- a/app/models/account/transaction_script_runner.rb
+++ b/app/models/account/transaction_script_runner.rb
@@ -1,0 +1,56 @@
+require "open3"
+require "json"
+
+class Account::TransactionScriptRunner
+  class PushTanRequired < StandardError; end
+
+  attr_reader :account
+
+  def initialize(account)
+    @account = account
+  end
+
+  def run
+    return 0 unless account.sync_script_path.present?
+
+    stdout, stderr, _status = Open3.capture3("python3", account.sync_script_path)
+
+    output = [ stdout, stderr ].join("\n")
+    if output.match?(/push[- ]?tan/i)
+      raise PushTanRequired, "pushTAN authorization required"
+    end
+
+    transactions = JSON.parse(stdout.presence || "[]")
+    added = 0
+
+    transactions.each do |tx|
+      date = Date.parse(tx["date"].to_s)
+      amount = BigDecimal(tx["amount"].to_s)
+      name = tx["name"].to_s
+      currency = tx["currency"].presence || account.currency
+
+      exists = account.entries.where(
+        date: date,
+        name: name,
+        amount: amount,
+        currency: currency,
+        entryable_type: "Transaction"
+      ).exists?
+      next if exists
+
+      account.entries.create!(
+        date: date,
+        name: name,
+        amount: amount,
+        currency: currency,
+        entryable: Transaction.new
+      )
+      added += 1
+    end
+
+    added
+  rescue JSON::ParserError => e
+    Rails.logger.error("Failed to parse transaction script output: #{e.message}")
+    0
+  end
+end

--- a/app/views/accounts/push_tan_required.html.erb
+++ b/app/views/accounts/push_tan_required.html.erb
@@ -1,0 +1,9 @@
+<turbo-frame id="modal">
+  <div class="p-6 text-center">
+    <div class="mb-4 flex justify-center">
+      <%= icon "smartphone", size: "2xl", color: "current" %>
+    </div>
+    <p class="mb-4">Bitte die pushTAN in deiner Banking-App bestätigen.</p>
+    <%= link_to "OK", "#", class: "flex justify-center px-4 py-2 border rounded-lg", data: { action: "click->modal#close" } %>
+  </div>
+</turbo-frame>

--- a/db/migrate/20250727120000_add_sync_script_path_to_accounts.rb
+++ b/db/migrate/20250727120000_add_sync_script_path_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddSyncScriptPathToAccounts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :accounts, :sync_script_path, :string
+  end
+end

--- a/test/models/account/transaction_script_runner_test.rb
+++ b/test/models/account/transaction_script_runner_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class TransactionScriptRunnerTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:depository)
+  end
+
+  test "imports new transactions" do
+    script = Tempfile.new([ "script", ".py" ])
+    script.write <<~PYTHON
+      import json
+      print(json.dumps([{"date": "2024-01-01", "name": "Test", "amount": "10.00", "currency": "USD"}]))
+    PYTHON
+    script.close
+
+    @account.update!(sync_script_path: script.path)
+
+    runner = Account::TransactionScriptRunner.new(@account)
+
+    assert_difference -> { @account.entries.count }, +1 do
+      assert_equal 1, runner.run
+    end
+  ensure
+    script.unlink
+  end
+
+  test "detects push tan requirement" do
+    script = Tempfile.new([ "script", ".py" ])
+    script.write <<~PYTHON
+      import sys, json
+      sys.stderr.write("Push-Tan needed")
+      print("[]")
+    PYTHON
+    script.close
+
+    @account.update!(sync_script_path: script.path)
+
+    runner = Account::TransactionScriptRunner.new(@account)
+
+    assert_raises(Account::TransactionScriptRunner::PushTanRequired) do
+      runner.run
+    end
+  ensure
+    script.unlink
+  end
+end


### PR DESCRIPTION
## Summary
- allow accounts to store a Python script path for syncing transactions
- run the script during account sync and broadcast a pushTAN modal if needed
- provide modal view and event infrastructure for pushTAN prompts

## Testing
- `bundle exec rubocop --format progress`
- `bundle exec rails test test/models/account/transaction_script_runner_test.rb` *(fails: PG::ConnectionBad - connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688e6dadc3848324ae42f6f220432e12