### PR TITLE
Add script-based transaction syncing with pushTAN handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ tasks.json
 .taskmaster/state.json
 *.mcp.json
 scripts/
+!app/views/settings/scripts/
 .cursor/mcp.json
 .taskmasterconfig
 .windsurfrules

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,5 +1,5 @@
 class AccountsController < ApplicationController
-  before_action :set_account, only: %i[sync sparkline toggle_active show destroy]
+  before_action :set_account, only: %i[sync run_script sparkline toggle_active show destroy]
   include Periodable
 
   def index
@@ -31,6 +31,15 @@ class AccountsController < ApplicationController
     end
 
     redirect_to account_path(@account)
+  end
+
+  def run_script
+    if request.post?
+      Account::TransactionScriptJob.perform_later(@account, procedure: params[:procedure], device: params[:device])
+      render partial: "accounts/script_running", locals: { account: @account }
+    else
+      render partial: "accounts/run_script", locals: { account: @account }
+    end
   end
 
   def sparkline

--- a/app/controllers/settings/scripts_controller.rb
+++ b/app/controllers/settings/scripts_controller.rb
@@ -1,0 +1,25 @@
+require "fileutils"
+
+class Settings::ScriptsController < ApplicationController
+  layout "settings"
+
+  def show
+    @accounts = Current.family.accounts.order(:name)
+    @account = @accounts.find_by(id: params[:account_id])
+    if @account&.sync_script_path.present? && File.exist?(@account.sync_script_path)
+      @script_contents = File.read(@account.sync_script_path)
+    end
+  end
+
+  def update
+    account = Current.family.accounts.find(params[:account_id])
+    if params[:script].present?
+      dir = Rails.root.join("storage", "scripts")
+      FileUtils.mkdir_p(dir)
+      path = dir.join("account_#{account.id}.py")
+      File.open(path, "wb") { |f| f.write(params[:script].read) }
+      account.update!(sync_script_path: path.to_s)
+    end
+    redirect_to settings_script_path(account_id: account.id), notice: "Script updated"
+  end
+end

--- a/app/jobs/account/transaction_script_job.rb
+++ b/app/jobs/account/transaction_script_job.rb
@@ -1,0 +1,11 @@
+class Account::TransactionScriptJob < ApplicationJob
+  queue_as :default
+
+  def perform(account, procedure: nil, device: nil)
+    Account::TransactionScriptRunner.new(account).run(procedure: procedure, device: device)
+    account.broadcast_sync_complete
+    Turbo::StreamsChannel.broadcast_replace_to(account.family, target: "modal", html: "")
+  rescue Account::TransactionScriptRunner::PushTanRequired
+    account.broadcast_push_tan_required
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -88,6 +88,14 @@ class Account < ApplicationRecord
     end
   end
 
+  # Path to custom Python script used for transaction syncing
+  validates :sync_script_path, length: { maximum: 255 }, allow_nil: true
+
+  # Broadcast a pushTAN requirement to the UI
+  def broadcast_push_tan_required
+    Account::PushTanRequiredEvent.new(self).broadcast
+  end
+
   def destroy_later
     mark_for_deletion!
     DestroyJob.perform_later(self)

--- a/app/models/account/push_tan_required_event.rb
+++ b/app/models/account/push_tan_required_event.rb
@@ -1,0 +1,16 @@
+class Account::PushTanRequiredEvent
+  attr_reader :account
+
+  def initialize(account)
+    @account = account
+  end
+
+  def broadcast
+    account.broadcast_replace_to(
+      account.family,
+      target: "modal",
+      partial: "accounts/push_tan_required",
+      locals: { account: account }
+    )
+  end
+end

--- a/app/models/account/syncer.rb
+++ b/app/models/account/syncer.rb
@@ -6,6 +6,7 @@ class Account::Syncer
   end
 
   def perform_sync(sync)
+    fetch_transactions_from_script
     Rails.logger.info("Processing balances (#{account.linked? ? 'reverse' : 'forward'})")
     import_market_data
     materialize_balances
@@ -33,5 +34,15 @@ class Account::Syncer
     rescue => e
       Rails.logger.error("Error syncing market data for account #{account.id}: #{e.message}")
       Sentry.capture_exception(e)
+    end
+
+    def fetch_transactions_from_script
+      return unless account.sync_script_path.present?
+
+      added = Account::TransactionScriptRunner.new(account).run
+      Rails.logger.info("Imported #{added} transactions via script for account #{account.id}")
+    rescue Account::TransactionScriptRunner::PushTanRequired
+      account.broadcast_push_tan_required
+      raise
     end
 end

--- a/app/models/account/transaction_script_runner.rb
+++ b/app/models/account/transaction_script_runner.rb
@@ -1,0 +1,60 @@
+require "open3"
+require "json"
+
+class Account::TransactionScriptRunner
+  class PushTanRequired < StandardError; end
+
+  attr_reader :account
+
+  def initialize(account)
+    @account = account
+  end
+
+  def run(procedure: nil, device: nil)
+    return 0 unless account.sync_script_path.present?
+
+    env = {}
+    env["TAN_PROCEDURE"] = procedure if procedure.present?
+    env["TAN_DEVICE"] = device if device.present?
+
+    stdout, stderr, _status = Open3.capture3(env, "python3", account.sync_script_path)
+
+    output = [ stdout, stderr ].join("\n")
+    if output.match?(/push[- ]?tan/i)
+      raise PushTanRequired, "pushTAN authorization required"
+    end
+
+    transactions = JSON.parse(stdout.presence || "[]")
+    added = 0
+
+    transactions.each do |tx|
+      date = Date.parse(tx["date"].to_s)
+      amount = BigDecimal(tx["amount"].to_s)
+      name = tx["name"].to_s
+      currency = tx["currency"].presence || account.currency
+
+      exists = account.entries.where(
+        date: date,
+        name: name,
+        amount: amount,
+        currency: currency,
+        entryable_type: "Transaction"
+      ).exists?
+      next if exists
+
+      account.entries.create!(
+        date: date,
+        name: name,
+        amount: amount,
+        currency: currency,
+        entryable: Transaction.new
+      )
+      added += 1
+    end
+
+    added
+  rescue JSON::ParserError => e
+    Rails.logger.error("Failed to parse transaction script output: #{e.message}")
+    0
+  end
+end

--- a/app/views/accounts/push_tan_required.html.erb
+++ b/app/views/accounts/push_tan_required.html.erb
@@ -1,0 +1,9 @@
+<turbo-frame id="modal">
+  <div class="p-6 text-center">
+    <div class="mb-4 flex justify-center">
+      <%= icon "smartphone", size: "2xl", color: "current" %>
+    </div>
+    <p class="mb-4">Bitte die pushTAN in deiner Banking-App bestätigen.</p>
+    <%= link_to "OK", "#", class: "flex justify-center px-4 py-2 border rounded-lg", data: { action: "click->modal#close" } %>
+  </div>
+</turbo-frame>

--- a/app/views/accounts/run_script.html.erb
+++ b/app/views/accounts/run_script.html.erb
@@ -1,0 +1,19 @@
+<turbo-frame id="modal">
+  <div class="p-6">
+    <%= form_with url: run_script_account_path(@account), method: :post, data: { turbo_frame: :modal } do |f| %>
+      <div class="space-y-4">
+        <div>
+          <%= f.label :procedure, "Verfahren", class: "block text-sm" %>
+          <%= f.text_field :procedure, class: "w-full" %>
+        </div>
+        <div>
+          <%= f.label :device, "Gerät", class: "block text-sm" %>
+          <%= f.text_field :device, class: "w-full" %>
+        </div>
+        <div class="flex justify-end">
+          <%= f.submit "Run", class: "px-4 py-2 border rounded-lg" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</turbo-frame>

--- a/app/views/accounts/script_running.html.erb
+++ b/app/views/accounts/script_running.html.erb
@@ -1,0 +1,8 @@
+<turbo-frame id="modal">
+  <div class="p-6 text-center space-y-4">
+    <div class="flex justify-center">
+      <%= icon "loader-circle", class: "animate-spin" %>
+    </div>
+    <p>Script wird ausgeführt...</p>
+  </div>
+</turbo-frame>

--- a/app/views/accounts/show/_header.html.erb
+++ b/app/views/accounts/show/_header.html.erb
@@ -36,6 +36,16 @@
             disabled: account.syncing?,
             frame: :_top
           ) %>
+        <% if account.sync_script_path.present? %>
+          <%= icon(
+              "play",
+              as_button: true,
+              size: "sm",
+              href: run_script_account_path(account),
+              disabled: account.syncing?,
+              data: { turbo_frame: :modal }
+            ) %>
+        <% end %>
       <% end %>
 
       <%= render "accounts/show/menu", account: account %>

--- a/app/views/settings/_settings_nav.html.erb
+++ b/app/views/settings/_settings_nav.html.erb
@@ -10,7 +10,8 @@ nav_sections = [
       { label: t(".self_hosting_label"), path: settings_hosting_path, icon: "database", if: self_hosted? },
       { label: t(".billing_label"), path: settings_billing_path, icon: "circle-dollar-sign", if: !self_hosted? },
       { label: t(".accounts_label"), path: accounts_path, icon: "layers" },
-      { label: t(".imports_label"), path: imports_path, icon: "download" }
+      { label: t(".imports_label"), path: imports_path, icon: "download" },
+      { label: t(".scripts_label"), path: settings_script_path, icon: "file-code" }
     ]
   },
   {

--- a/app/views/settings/scripts/show.html.erb
+++ b/app/views/settings/scripts/show.html.erb
@@ -1,0 +1,35 @@
+<%= content_for :page_title, t(".page_title") %>
+
+<%= settings_section title: t(".section_title") do %>
+  <div class="space-y-6">
+    <%= form_with url: settings_script_path, method: :get, local: true do |f| %>
+      <div class="space-y-2">
+        <%= f.label :account_id, t(".account_label"), class: "block text-sm" %>
+        <%= f.collection_select :account_id, @accounts, :id, :name, { prompt: t(".select_account") }, { class: "w-full" } %>
+      </div>
+      <div class="mt-4">
+        <%= f.submit t(".choose"), class: "px-4 py-2 border rounded-lg" %>
+      </div>
+    <% end %>
+
+    <% if @account %>
+      <%= form_with url: settings_script_path, method: :put, multipart: true, local: true do |f| %>
+        <%= hidden_field_tag :account_id, @account.id %>
+        <div class="space-y-2">
+          <%= f.label :script, t(".script_label"), class: "block text-sm" %>
+          <%= f.file_field :script, accept: ".py" %>
+        </div>
+        <div class="mt-4">
+          <%= f.submit t(".upload"), class: "px-4 py-2 border rounded-lg" %>
+        </div>
+      <% end %>
+
+      <% if @script_contents.present? %>
+        <div>
+          <h3 class="text-sm font-medium mb-2"><%= t(".current_script") %></h3>
+          <pre class="bg-surface-inset p-4 rounded text-xs whitespace-pre-wrap"><%= @script_contents %></pre>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 3 } %>
   host: <%= ENV.fetch("DB_HOST") { "127.0.0.1" } %>
   port: <%= ENV.fetch("DB_PORT") { "5432" } %>
-  user: <%= ENV.fetch("POSTGRES_USER") { nil } %>
+  username: <%= ENV.fetch("POSTGRES_USER") { "postgres" } %>
   password: <%= ENV.fetch("POSTGRES_PASSWORD") { nil } %>
 
 development:

--- a/config/locales/views/settings/de.yml
+++ b/config/locales/views/settings/de.yml
@@ -71,6 +71,16 @@ de:
     securities:
       show:
         page_title: Sicherheit
+    scripts:
+      show:
+        page_title: Skripte
+        section_title: Skripte verwalten
+        account_label: Konto
+        select_account: Konto auswählen
+        choose: Auswählen
+        script_label: Python-Skript
+        upload: Hochladen
+        current_script: Aktuelles Skript
     settings_nav:
       accounts_label: Konten
       api_key_label: API-Schlüssel
@@ -79,6 +89,7 @@ de:
       feedback_label: Feedback
       general_section_title: Allgemein
       imports_label: Importe
+      scripts_label: Skripte
       logout: Abmelden
       merchants_label: Händler
       other_section_title: Mehr

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -68,6 +68,16 @@ en:
     securities:
       show:
         page_title: Security
+    scripts:
+      show:
+        page_title: Scripts
+        section_title: Manage Scripts
+        account_label: Account
+        select_account: Select account
+        choose: Choose
+        script_label: Python script
+        upload: Upload
+        current_script: Current script
     settings_nav:
       accounts_label: Accounts
       api_key_label: API Key
@@ -76,6 +86,7 @@ en:
       feedback_label: Feedback
       general_section_title: General
       imports_label: Imports
+      scripts_label: Scripts
       logout: Logout
       merchants_label: Merchants
       other_section_title: More

--- a/config/locales/views/settings/nb.yml
+++ b/config/locales/views/settings/nb.yml
@@ -67,6 +67,16 @@ nb:
     securities:
       show:
         page_title: Sikkerhet
+    scripts:
+      show:
+        page_title: Skript
+        section_title: Administrer skript
+        account_label: Konto
+        select_account: Velg konto
+        choose: Velg
+        script_label: Python-skript
+        upload: Last opp
+        current_script: Gjeldende skript
     settings_nav:
       accounts_label: Kontoer
       api_key_label: API-nøkkel
@@ -75,6 +85,7 @@ nb:
       feedback_label: Tilbakemelding
       general_section_title: Generelt
       imports_label: Importer
+      scripts_label: Skript
       logout: Logg ut
       merchants_label: Forhandlere
       other_section_title: Mer

--- a/config/locales/views/settings/tr.yml
+++ b/config/locales/views/settings/tr.yml
@@ -65,6 +65,16 @@ tr:
     securities:
       show:
         page_title: Menkul Kıymet
+    scripts:
+      show:
+        page_title: Komut Dosyaları
+        section_title: Komut dosyalarını yönet
+        account_label: Hesap
+        select_account: Hesap seç
+        choose: Seç
+        script_label: Python komut dosyası
+        upload: Yükle
+        current_script: Mevcut komut dosyası
     settings_nav:
       accounts_label: Hesaplar
       api_key_label: API Anahtarı
@@ -73,6 +83,7 @@ tr:
       feedback_label: Geri Bildirim
       general_section_title: Genel
       imports_label: İçe Aktarımlar
+      scripts_label: Komut Dosyaları
       logout: Çıkış Yap
       merchants_label: Satıcılar
       other_section_title: Diğer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
     resource :billing, only: :show
     resource :security, only: :show
     resource :api_key, only: [ :show, :new, :create, :destroy ]
+    resource :script, only: %i[show update]
   end
 
   resource :subscription, only: %i[new show create] do
@@ -159,6 +160,8 @@ Rails.application.routes.draw do
   resources :accounts, only: %i[index new show destroy], shallow: true do
     member do
       post :sync
+      get :run_script
+      post :run_script
       get :sparkline
       patch :toggle_active
     end

--- a/db/migrate/20250727120000_add_sync_script_path_to_accounts.rb
+++ b/db/migrate/20250727120000_add_sync_script_path_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddSyncScriptPathToAccounts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :accounts, :sync_script_path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_24_115507) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_27_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_24_115507) do
     t.decimal "cash_balance", precision: 19, scale: 4, default: "0.0"
     t.jsonb "locked_attributes", default: {}
     t.string "status", default: "active"
+    t.string "sync_script_path"
     t.index ["accountable_id", "accountable_type"], name: "index_accounts_on_accountable_id_and_accountable_type"
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["currency"], name: "index_accounts_on_currency"

--- a/test/controllers/settings/scripts_controller_test.rb
+++ b/test/controllers/settings/scripts_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class Settings::ScriptsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_member)
+    @account = accounts(:depository)
+  end
+
+  test "shows script settings" do
+    get settings_script_path
+    assert_response :success
+  end
+
+  test "uploads script for account" do
+    file = Tempfile.new([ "script", ".py" ])
+    file.write("print('hi')")
+    file.rewind
+
+    upload = Rack::Test::UploadedFile.new(file.path, "text/x-python")
+    patch settings_script_path, params: { account_id: @account.id, script: upload }
+    assert_redirected_to settings_script_path(account_id: @account.id)
+    @account.reload
+    assert @account.sync_script_path.present?
+  ensure
+    file.close
+    file.unlink
+  end
+end

--- a/test/models/account/transaction_script_runner_test.rb
+++ b/test/models/account/transaction_script_runner_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class TransactionScriptRunnerTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:depository)
+  end
+
+  test "imports new transactions" do
+    script = Tempfile.new([ "script", ".py" ])
+    script.write <<~PYTHON
+      import json
+      print(json.dumps([{"date": "2024-01-01", "name": "Test", "amount": "10.00", "currency": "USD"}]))
+    PYTHON
+    script.close
+
+    @account.update!(sync_script_path: script.path)
+
+    runner = Account::TransactionScriptRunner.new(@account)
+
+    assert_difference -> { @account.entries.count }, +1 do
+      assert_equal 1, runner.run
+    end
+  ensure
+    script.unlink
+  end
+
+  test "detects push tan requirement" do
+    script = Tempfile.new([ "script", ".py" ])
+    script.write <<~PYTHON
+      import sys, json
+      sys.stderr.write("Push-Tan needed")
+      print("[]")
+    PYTHON
+    script.close
+
+    @account.update!(sync_script_path: script.path)
+
+    runner = Account::TransactionScriptRunner.new(@account)
+
+    assert_raises(Account::TransactionScriptRunner::PushTanRequired) do
+      runner.run
+    end
+  ensure
+    script.unlink
+  end
+end


### PR DESCRIPTION
## Summary
- allow accounts to store a Python script path for syncing transactions
- run the script during account sync and broadcast a pushTAN modal if needed
- provide modal view and event infrastructure for pushTAN prompts
- add settings page to upload scripts per account and a button to trigger them
- configure local PostgreSQL defaults and add script settings tests

## Testing
- `bundle exec rubocop --format progress`
- `POSTGRES_PASSWORD=postgres bundle exec rails test test/models/account/transaction_script_runner_test.rb test/controllers/settings/scripts_controller_test.rb`


------
https://chatgpt.com/codex/tasks/task_e_688e6dadc3848324ae42f6f220432e12