### PR TITLE
Add styled modal and output logging for Python account scripts

### DIFF
--- a/app/jobs/account/transaction_script_job.rb
+++ b/app/jobs/account/transaction_script_job.rb
@@ -2,9 +2,9 @@ class Account::TransactionScriptJob < ApplicationJob
   queue_as :default
 
   def perform(account, procedure: nil, device: nil)
-    Account::TransactionScriptRunner.new(account).run(procedure: procedure, device: device)
+    result = Account::TransactionScriptRunner.new(account).run(procedure: procedure, device: device)
+    account.broadcast_script_output(result.output)
     account.broadcast_sync_complete
-    Turbo::StreamsChannel.broadcast_replace_to(account.family, target: "modal", html: "")
   rescue Account::TransactionScriptRunner::PushTanRequired
     account.broadcast_push_tan_required
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -96,6 +96,11 @@ class Account < ApplicationRecord
     Account::PushTanRequiredEvent.new(self).broadcast
   end
 
+  # Broadcast transaction script output to the UI
+  def broadcast_script_output(output)
+    Account::ScriptOutputEvent.new(self, output).broadcast
+  end
+
   def destroy_later
     mark_for_deletion!
     DestroyJob.perform_later(self)

--- a/app/models/account/script_output_event.rb
+++ b/app/models/account/script_output_event.rb
@@ -1,0 +1,17 @@
+class Account::ScriptOutputEvent
+  attr_reader :account, :output
+
+  def initialize(account, output)
+    @account = account
+    @output = output
+  end
+
+  def broadcast
+    account.broadcast_replace_to(
+      account.family,
+      target: "modal",
+      partial: "accounts/script_output",
+      locals: { account: account, output: output }
+    )
+  end
+end

--- a/app/views/accounts/_run_script.html.erb
+++ b/app/views/accounts/_run_script.html.erb
@@ -1,19 +1,12 @@
-<turbo-frame id="modal">
-  <div class="p-6">
-    <%= form_with url: run_script_account_path(@account), method: :post, data: { turbo_frame: :modal } do |f| %>
-      <div class="space-y-4">
-        <div>
-          <%= f.label :procedure, "Verfahren", class: "block text-sm" %>
-          <%= f.text_field :procedure, class: "w-full" %>
-        </div>
-        <div>
-          <%= f.label :device, "Gerät", class: "block text-sm" %>
-          <%= f.text_field :device, class: "w-full" %>
-        </div>
-        <div class="flex justify-end">
-          <%= f.submit "Run", class: "px-4 py-2 border rounded-lg" %>
-        </div>
+<%= render DS::Dialog.new do |dialog| %>
+  <% dialog.with_header(title: "Python Script ausführen") %>
+  <% dialog.with_body do %>
+    <%= styled_form_with url: run_script_account_path(@account), method: :post, data: { turbo_frame: :modal }, class: "space-y-4" do |form| %>
+      <%= form.text_field :procedure, label: "Verfahren" %>
+      <%= form.text_field :device, label: "Gerät" %>
+      <div class="flex justify-end">
+        <%= form.submit "Run", class: "bg-inverse fg-inverse rounded-lg px-4 py-2" %>
       </div>
     <% end %>
-  </div>
-</turbo-frame>
+  <% end %>
+<% end %>

--- a/app/views/accounts/_script_output.html.erb
+++ b/app/views/accounts/_script_output.html.erb
@@ -1,0 +1,6 @@
+<%= render DS::Dialog.new do |dialog| %>
+  <% dialog.with_header(title: "Script Output") %>
+  <% dialog.with_body do %>
+    <pre class="whitespace-pre-wrap text-left text-sm"><%= output.presence || "" %></pre>
+  <% end %>
+<% end %>

--- a/app/views/accounts/_script_running.html.erb
+++ b/app/views/accounts/_script_running.html.erb
@@ -1,8 +1,10 @@
-<turbo-frame id="modal">
-  <div class="p-6 text-center space-y-4">
-    <div class="flex justify-center">
-      <%= icon "loader-circle", class: "animate-spin" %>
+<%= render DS::Dialog.new do |dialog| %>
+  <% dialog.with_body do %>
+    <div class="py-6 text-center space-y-4">
+      <div class="flex justify-center">
+        <%= icon "loader-circle", class: "animate-spin" %>
+      </div>
+      <p>Script wird ausgeführt...</p>
     </div>
-    <p>Script wird ausgeführt...</p>
-  </div>
-</turbo-frame>
+  <% end %>
+<% end %>

--- a/app/views/accounts/show/_header.html.erb
+++ b/app/views/accounts/show/_header.html.erb
@@ -43,7 +43,7 @@
               size: "sm",
               href: run_script_account_path(account),
               disabled: account.syncing?,
-              data: { turbo_frame: :modal }
+              frame: :modal
             ) %>
         <% end %>
       <% end %>

--- a/test/models/account/transaction_script_runner_test.rb
+++ b/test/models/account/transaction_script_runner_test.rb
@@ -18,7 +18,9 @@ class TransactionScriptRunnerTest < ActiveSupport::TestCase
     runner = Account::TransactionScriptRunner.new(@account)
 
     assert_difference -> { @account.entries.count }, +1 do
-      assert_equal 1, runner.run
+      result = runner.run
+      assert_equal 1, result.added
+      assert_match "Test", result.output
     end
   ensure
     script.unlink


### PR DESCRIPTION
## Summary
- show Python account scripts in a DS modal when the play icon is pressed
- broadcast and display script stdout/stderr in a modal after execution
- log script output and update TransactionScriptRunner API

## Testing
- `bundle exec rubocop app/models/account/transaction_script_runner.rb app/models/account.rb app/jobs/account/transaction_script_job.rb app/models/account/script_output_event.rb test/models/account/transaction_script_runner_test.rb`
- `bundle exec rails test` *(fails: There is an issue connecting with your hostname: 127.0.0.1)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e855ba2e88324adc2b73a137c41ba