### PR TITLE
Add FinTS API integration

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,5 +1,5 @@
 class AccountsController < ApplicationController
-  before_action :set_account, only: %i[sync run_script sparkline toggle_active show destroy]
+  before_action :set_account, only: %i[sync run_script fetch_fints import_fints sparkline toggle_active show destroy]
   include Periodable
 
   def index
@@ -40,6 +40,15 @@ class AccountsController < ApplicationController
     else
       render partial: "accounts/run_script", locals: { account: @account }
     end
+  end
+
+  def fetch_fints
+    render partial: "accounts/fetch_fints", locals: { account: @account }
+  end
+
+  def import_fints
+    added = Account::FintsCsvImporter.new(@account, params.require(:csv)).import!
+    render json: { added: added }
   end
 
   def sparkline

--- a/app/javascript/controllers/fints_controller.js
+++ b/app/javascript/controllers/fints_controller.js
@@ -1,0 +1,92 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="fints"
+export default class extends Controller {
+  static values = {
+    baseUrl: String,
+    accountId: String,
+  };
+
+  static targets = ["days", "pin", "status", "confirmButton"];
+
+  start() {
+    const days = parseInt(this.daysTarget.value || "30", 10);
+    const headers = { "Content-Type": "application/json" };
+    if (this.pinTarget.value) {
+      headers["x-pin"] = this.pinTarget.value;
+    }
+    this.updateStatus("Starting session...");
+    fetch(`${this.baseUrlValue}/sessions`, {
+      method: "POST",
+      headers: headers,
+      body: JSON.stringify({ days: days }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        this.sessionId = data.session_id;
+        this.poll();
+      })
+      .catch((e) => this.updateStatus(`Error: ${e}`));
+  }
+
+  poll() {
+    fetch(`${this.baseUrlValue}/sessions/${this.sessionId}`)
+      .then((r) => r.json())
+      .then((data) => {
+        switch (data.status) {
+          case "pending":
+          case "processing":
+            this.updateStatus(data.status);
+            setTimeout(() => this.poll(), 2000);
+            break;
+          case "need_confirmation":
+            this.updateStatus(data.challenge || data.hint || "Confirmation required");
+            this.confirmButtonTarget.classList.remove("hidden");
+            break;
+          case "done":
+            this.updateStatus("Downloading...");
+            this.downloadResult();
+            break;
+          case "error":
+            this.updateStatus(data.error || "Error");
+            break;
+        }
+      })
+      .catch((e) => this.updateStatus(`Error: ${e}`));
+  }
+
+  confirm() {
+    this.confirmButtonTarget.classList.add("hidden");
+    fetch(`${this.baseUrlValue}/sessions/${this.sessionId}`, { method: "POST" })
+      .then(() => {
+        this.updateStatus("Processing...");
+        setTimeout(() => this.poll(), 2000);
+      })
+      .catch((e) => this.updateStatus(`Error: ${e}`));
+  }
+
+  downloadResult() {
+    fetch(`${this.baseUrlValue}/sessions/${this.sessionId}/result`)
+      .then((r) => r.text())
+      .then((csv) => {
+        this.updateStatus("Importing...");
+        return fetch(`/accounts/${this.accountIdValue}/import_fints`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": document.querySelector('[name="csrf-token"]').content,
+          },
+          body: JSON.stringify({ csv: csv }),
+        });
+      })
+      .then((r) => r.json())
+      .then((data) => {
+        this.updateStatus(`Imported ${data.added} transactions`);
+      })
+      .catch((e) => this.updateStatus(`Error: ${e}`));
+  }
+
+  updateStatus(text) {
+    this.statusTarget.textContent = text;
+  }
+}

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -90,6 +90,7 @@ class Account < ApplicationRecord
 
   # Path to custom Python script used for transaction syncing
   validates :sync_script_path, length: { maximum: 255 }, allow_nil: true
+  validates :fints_api_base_url, length: { maximum: 255 }, allow_nil: true
 
   # Broadcast a pushTAN requirement to the UI
   def broadcast_push_tan_required

--- a/app/models/account/fints_csv_importer.rb
+++ b/app/models/account/fints_csv_importer.rb
@@ -1,0 +1,45 @@
+require 'csv'
+
+class Account::FintsCsvImporter
+  attr_reader :account, :csv_data
+
+  def initialize(account, csv_data)
+    @account = account
+    @csv_data = csv_data
+  end
+
+  # Imports CSV data in Sparkasse format and returns number of new entries added
+  def import!
+    rows = CSV.parse(csv_data, headers: true)
+    added = 0
+    rows.each do |row|
+      begin
+        date = Date.strptime(row['date*'], '%m/%d/%Y')
+        amount = BigDecimal(row['amount*'])
+        name = row['name'].to_s
+        currency = row['currency'].presence || account.currency
+      rescue
+        next
+      end
+
+      exists = account.entries.where(
+        date: date,
+        name: name,
+        amount: amount,
+        currency: currency,
+        entryable_type: 'Transaction'
+      ).exists?
+      next if exists
+
+      account.entries.create!(
+        date: date,
+        name: name,
+        amount: amount,
+        currency: currency,
+        entryable: Transaction.new
+      )
+      added += 1
+    end
+    added
+  end
+end

--- a/app/views/accounts/_fetch_fints.html.erb
+++ b/app/views/accounts/_fetch_fints.html.erb
@@ -1,0 +1,22 @@
+<%= render DS::Dialog.new do |dialog| %>
+  <% dialog.with_header(title: 'Fetch Transactions') %>
+  <% dialog.with_body do %>
+    <div data-controller="fints" data-fints-base-url-value="<%= account.fints_api_base_url %>" data-fints-account-id-value="<%= account.id %>" class="space-y-4">
+      <div>
+        <label class="block text-sm font-medium text-secondary mb-1">Days</label>
+        <input type="number" value="30" data-fints-target="days" class="w-full bg-container-inset border border-secondary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-secondary text-primary" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-secondary mb-1">PIN (optional)</label>
+        <input type="password" data-fints-target="pin" class="w-full bg-container-inset border border-secondary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-secondary text-primary" />
+      </div>
+      <div data-fints-target="status" class="text-center text-sm text-secondary"></div>
+      <div class="flex justify-center">
+        <button type="button" data-action="fints#confirm" data-fints-target="confirmButton" class="hidden px-4 py-2 border rounded-lg">Confirm</button>
+      </div>
+      <div class="flex justify-end">
+        <%= render DS::Button.new(text: 'Start', type: 'button', class: 'font-medium whitespace-nowrap inline-flex items-center gap-1 rounded-md px-4 py-2 text-sm bg-gray-50 hover:bg-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100', data: { action: 'fints#start' }) %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/accounts/show/_header.html.erb
+++ b/app/views/accounts/show/_header.html.erb
@@ -36,7 +36,16 @@
             disabled: account.syncing?,
             frame: :_top
           ) %>
-        <% if account.sync_script_path.present? %>
+        <% if account.fints_api_base_url.present? %>
+          <%= icon(
+              "play",
+              as_button: true,
+              size: "sm",
+              href: fetch_fints_account_path(account),
+              disabled: account.syncing?,
+              frame: :modal
+            ) %>
+        <% elsif account.sync_script_path.present? %>
           <%= icon(
               "play",
               as_button: true,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,8 @@ Rails.application.routes.draw do
       post :sync
       get :run_script
       post :run_script
+      get :fetch_fints
+      post :import_fints
       get :sparkline
       patch :toggle_active
     end

--- a/db/migrate/20250803153934_add_fints_api_base_url_to_accounts.rb
+++ b/db/migrate/20250803153934_add_fints_api_base_url_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddFintsApiBaseUrlToAccounts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :accounts, :fints_api_base_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_27_120000) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_03_153934) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_27_120000) do
     t.jsonb "locked_attributes", default: {}
     t.string "status", default: "active"
     t.string "sync_script_path"
+    t.string "fints_api_base_url"
     t.index ["accountable_id", "accountable_type"], name: "index_accounts_on_accountable_id_and_accountable_type"
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["currency"], name: "index_accounts_on_currency"

--- a/test/models/account/fints_csv_importer_test.rb
+++ b/test/models/account/fints_csv_importer_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class FintsCsvImporterTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:depository)
+  end
+
+  test "imports new transactions and ignores duplicates" do
+    csv = <<~CSV
+      date*,amount*,name,currency,category,tags,account,notes
+      01/02/2024,-10.00,Test,USD,,,
+    CSV
+
+    importer = Account::FintsCsvImporter.new(@account, csv)
+
+    assert_difference -> { @account.entries.count }, +1 do
+      added = importer.import!
+      assert_equal 1, added
+    end
+
+    importer = Account::FintsCsvImporter.new(@account, csv)
+    assert_no_difference -> { @account.entries.count } do
+      added = importer.import!
+      assert_equal 0, added
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- allow configuring a FinTS API endpoint per account
- add client-side workflow to start and monitor FinTS sessions
- import resulting CSV transactions into the selected account

## Testing
- `bin/rails test` *(fails: StandardError expected but nothing was raised; InviteCode.count didn't change; 9 failures, 78 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f8142f9008324a7d98684ec15199a