### PR TITLE
Fix FinTS challenge confirmation endpoint

### DIFF
--- a/app/controllers/accounts/fints_sessions_controller.rb
+++ b/app/controllers/accounts/fints_sessions_controller.rb
@@ -20,7 +20,7 @@ module Accounts
     end
 
     def confirm
-      response = client.post("/sessions/#{params[:id]}")
+      response = client.post("/sessions/#{params[:id]}/confirm")
       render json: JSON.parse(response.body), status: response.status
     rescue Faraday::Error => e
       render json: { error: e.message }, status: :bad_gateway

--- a/app/views/accounts/_fetch_fints.html.erb
+++ b/app/views/accounts/_fetch_fints.html.erb
@@ -1,21 +1,21 @@
 <%= render DS::Dialog.new do |dialog| %>
-  <% dialog.with_header(title: 'Fetch Transactions') %>
+  <% dialog.with_header(title: "Fetch Transactions") %>
   <% dialog.with_body do %>
     <div data-controller="fints" data-fints-account-id-value="<%= account.id %>" class="space-y-4">
       <div>
         <label class="block text-sm font-medium text-secondary mb-1">Days</label>
-        <input type="number" value="30" data-fints-target="days" class="w-full bg-container-inset border border-secondary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-secondary text-primary" />
+        <input type="number" value="30" autocomplete="off" data-fints-target="days" class="w-full bg-container-inset border border-secondary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-secondary text-primary">
       </div>
       <div>
         <label class="block text-sm font-medium text-secondary mb-1">PIN (optional)</label>
-        <input type="password" data-fints-target="pin" class="w-full bg-container-inset border border-secondary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-secondary text-primary" />
+        <input type="password" autocomplete="off" data-fints-target="pin" class="w-full bg-container-inset border border-secondary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-secondary text-primary">
       </div>
       <div data-fints-target="status" class="text-center text-sm text-secondary"></div>
       <div class="flex justify-center">
-        <%= render DS::Button.new(text: 'Confirm', type: 'button', class: 'hidden', data: { action: 'fints#confirm', fints_target: 'confirmButton' }) %>
+        <%= render DS::Button.new(text: "Confirm", type: "button", class: "hidden", data: { action: "fints#confirm", fints_target: "confirmButton" }) %>
       </div>
       <div class="flex justify-end">
-        <%= render DS::Button.new(text: 'Start', type: 'button', data: { action: 'fints#start' }) %>
+        <%= render DS::Button.new(text: "Start", type: "button", data: { action: "fints#start" }) %>
       </div>
     </div>
   <% end %>

--- a/test/controllers/accounts/fints_sessions_controller_test.rb
+++ b/test/controllers/accounts/fints_sessions_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class Accounts::FintsSessionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+    @account = accounts(:depository)
+    @account.update!(fints_api_base_url: "http://example.com")
+  end
+
+  test "confirm posts to fints api" do
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.post("/sessions/123/confirm") { [ 200, {}, { status: "processing" }.to_json ] }
+    end
+
+    connection = Faraday.new do |builder|
+      builder.request :json
+      builder.response :raise_error
+      builder.adapter :test, stubs
+    end
+
+    Accounts::FintsSessionsController.any_instance.stubs(:client).returns(connection)
+
+    post confirm_account_fints_session_path(account_id: @account.id, id: "123")
+    assert_response :success
+
+    stubs.verify_stubbed_calls
+  end
+end


### PR DESCRIPTION
## Summary
- post to FinTS `/sessions/:id/confirm` endpoint when confirming a challenge
- ensure FinTS fetch form inputs disable browser autocomplete
- test FinTS challenge confirmation flow

## Testing
- `bin/rubocop -f github -a app/controllers/accounts/fints_sessions_controller.rb test/controllers/accounts/fints_sessions_controller_test.rb`
- `bundle exec erb_lint ./app/**/*.erb -a`
- `bin/brakeman --no-pager`
- `bin/rails test` *(fails: there is an issue connecting with your hostname: 127.0.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_688f94e0794083249c84d649cf342ffe